### PR TITLE
fixing updating gcal event

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Google Calendar to Discord Sync Bot
+# GCal2Discord - Google Calendar to Discord Sync Bot
 
 This bot syncs events from a Google Calendar to a Discord server. It periodically checks for new events, updates existing ones, and ensures events deleted from Discord are recreated if they still exist in Google Calendar. Google Calendar has authoritative control over the events.
 

--- a/main.py
+++ b/main.py
@@ -11,33 +11,41 @@ import os
 import tarfile
 import time
 
-# Path to the file that stores synchronized events
+# File paths for storing synchronized events and logs
 SYNCED_EVENTS_FILE = 'synced_events.json'
 EVENT_LOG_FILE = 'event.log'
 LOG_SIZE_LIMIT = 200 * 1024 * 1024  # 200 MB
 
-# Load synchronized events from file
 def load_synced_events():
+    """
+    Load the list of events that have been synchronized from the local JSON file.
+    """
     if os.path.exists(SYNCED_EVENTS_FILE):
         with open(SYNCED_EVENTS_FILE, 'r') as f:
             return json.load(f)
     return {"events": []}
 
-# Save synchronized events to file
 def save_synced_events(synced_events):
+    """
+    Save the list of synchronized events to the local JSON file.
+    """
     with open(SYNCED_EVENTS_FILE, 'w') as f:
         json.dump(synced_events, f, indent=4)
 
-# Log an event
 def log_event(message):
+    """
+    Log messages with a timestamp to the event log file.
+    """
     timestamp = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
     log_message = f"{timestamp} {message}\n"
     with open(EVENT_LOG_FILE, 'a') as log_file:
         log_file.write(log_message)
     check_log_size()
 
-# Check the size of the log file and compress if needed
 def check_log_size():
+    """
+    Check the size of the event log file and compress it if it exceeds the limit.
+    """
     if os.path.exists(EVENT_LOG_FILE) and os.path.getsize(EVENT_LOG_FILE) > LOG_SIZE_LIMIT:
         timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
         tar_filename = f"{timestamp}.tar.gz"
@@ -46,27 +54,37 @@ def check_log_size():
         os.remove(EVENT_LOG_FILE)
         log_event(f"Log file compressed to {tar_filename} and reset.")
 
-# Set up Google Calendar API
 def get_google_calendar_service():
+    """
+    Set up the Google Calendar API service using the provided credentials.
+    """
     credentials, _ = google.auth.load_credentials_from_file(var.GOOGLE_CREDENTIALS_JSON)
     service = build('calendar', 'v3', credentials=credentials)
     return service
 
-# Fetch upcoming events from Google Calendar
 def get_upcoming_events(service):
+    """
+    Fetch upcoming events from Google Calendar within the specified time frame.
+    """
     log_event(f"Requesting events from Google Calendar for the next {var.DAYS_IN_FUTURE} days.")
     now = datetime.datetime.utcnow()
     time_min = now.strftime('%Y-%m-%dT%H:%M:%S') + 'Z'
     time_max = (now + datetime.timedelta(days=var.DAYS_IN_FUTURE)).strftime('%Y-%m-%dT%H:%M:%S') + 'Z'
 
     events_result = service.events().list(
-        calendarId=var.GOOGLE_CALENDAR_ID, timeMin=time_min, timeMax=time_max,
-        maxResults=100, singleEvents=True,
-        orderBy='startTime').execute()
+        calendarId=var.GOOGLE_CALENDAR_ID,
+        timeMin=time_min,
+        timeMax=time_max,
+        maxResults=100,
+        singleEvents=True,
+        orderBy='startTime'
+    ).execute()
     return events_result.get('items', [])
 
-# Fetch existing Discord events
 def get_discord_events():
+    """
+    Fetch existing scheduled events from the Discord server.
+    """
     log_event("Requesting events from Discord.")
     url = f"https://discord.com/api/v9/guilds/{var.DISCORD_GUILD_ID}/scheduled-events"
     headers = {
@@ -79,15 +97,25 @@ def get_discord_events():
         log_event(f"Failed to fetch Discord events: {response.content}")
         return []
 
-# Create or update Discord event
 def create_or_update_discord_event(event, discord_event_id=None):
-    url = f"https://discord.com/api/v9/guilds/{var.DISCORD_GUILD_ID}/scheduled-events"
-    method = requests.post if discord_event_id is None else requests.patch
+    """
+    Create a new scheduled event on Discord or update an existing one.
+    """
+    if discord_event_id is None:
+        # Creating a new event
+        url = f"https://discord.com/api/v9/guilds/{var.DISCORD_GUILD_ID}/scheduled-events"
+        method = requests.post
+    else:
+        # Updating an existing event
+        url = f"https://discord.com/api/v9/guilds/{var.DISCORD_GUILD_ID}/scheduled-events/{discord_event_id}"
+        method = requests.patch
 
     headers = {
         "Authorization": f"Bot {var.DISCORD_BOT_TOKEN}",
         "Content-Type": "application/json"
     }
+
+    # Get start and end times, handling all-day events
     start_time = event['start'].get('dateTime', event['start'].get('date'))
     end_time = event['end'].get('dateTime', event['end'].get('date'))
 
@@ -106,28 +134,32 @@ def create_or_update_discord_event(event, discord_event_id=None):
     }
 
     response = method(url, json=data, headers=headers)
-    time.sleep(2)
+    time.sleep(2)  # Pause to respect rate limits
     if response.status_code in (200, 201):
-        log_event(f"Event {event['summary']} {'updated' if discord_event_id else 'created'} on Discord")
+        action = 'updated' if discord_event_id else 'created'
+        log_event(f"Event {event['summary']} {action} on Discord")
         return response.json().get('id')
     else:
-        log_event(f"Failed to {'update' if discord_event_id else 'create'} event {event['summary']} on Discord: {response.content}")
+        action = 'update' if discord_event_id else 'create'
+        log_event(f"Failed to {action} event {event['summary']} on Discord: {response.content}")
         return None
 
-# Delete Discord event
 def delete_discord_event(event_id):
+    """
+    Delete a scheduled event from Discord using its event ID.
+    """
     url = f"https://discord.com/api/v9/guilds/{var.DISCORD_GUILD_ID}/scheduled-events/{event_id}"
     headers = {
         "Authorization": f"Bot {var.DISCORD_BOT_TOKEN}"
     }
     response = requests.delete(url, headers=headers)
-    time.sleep(2)
+    time.sleep(2)  # Pause to respect rate limits
     if response.status_code == 204:
         log_event(f"Event {event_id} deleted from Discord")
     else:
         log_event(f"Failed to delete event {event_id} from Discord: {response.content}")
 
-# Set up Discord bot
+# Set up the Discord bot with the necessary intents
 intents = Intents.default()
 intents.message_content = True
 bot = commands.Bot(command_prefix='!', intents=intents)
@@ -136,11 +168,17 @@ synced_events = load_synced_events()
 
 @bot.event
 async def on_ready():
+    """
+    Event handler for when the bot is ready and connected to Discord.
+    """
     log_event("Bot logged in and ready.")
     sync_events_loop.start()
 
 @tasks.loop(seconds=var.SYNC_INTERVAL)
 async def sync_events_loop():
+    """
+    Periodically synchronize events from Google Calendar to Discord.
+    """
     try:
         service = get_google_calendar_service()
         events = get_upcoming_events(service)
@@ -151,7 +189,7 @@ async def sync_events_loop():
         discord_event_ids = {event['id'] for event in discord_events}
 
         for event in events:
-            time.sleep(2)
+            time.sleep(2)  # Pause to respect rate limits
             event_id = event['id']
             event_data = {
                 "date": event['start'].get('dateTime', event['start'].get('date')),
@@ -160,19 +198,28 @@ async def sync_events_loop():
                 "notes": event.get('description', '')
             }
 
+            # Check if the event has already been synchronized
             if any(e["google_event_id"] == event_id for e in synced_events["events"]):
                 for synced_event in synced_events["events"]:
                     if synced_event["google_event_id"] == event_id:
                         discord_event_id = synced_event["discord_event_id"]
                         if discord_event_id not in discord_event_ids:
+                            # The event is missing on Discord, recreate it
                             log_event(f"Event {event['summary']} is missing on Discord, recreating")
-                            discord_event_id = create_or_update_discord_event(event, discord_event_id)
+                            discord_event_id = create_or_update_discord_event(event)
                             if discord_event_id:
                                 synced_event["discord_event_id"] = discord_event_id
                                 synced_event.update(event_data)
                                 save_synced_events(synced_events)
+                        else:
+                            # Update the existing Discord event
+                            discord_event_id = create_or_update_discord_event(event, discord_event_id)
+                            if discord_event_id:
+                                synced_event.update(event_data)
+                                save_synced_events(synced_events)
                         break
             else:
+                # The event is new, create it on Discord
                 discord_event_id = create_or_update_discord_event(event)
                 if discord_event_id:
                     synced_events["events"].append({
@@ -182,10 +229,10 @@ async def sync_events_loop():
                     })
                     save_synced_events(synced_events)
 
-        # Remove events from synced_events if they no longer exist in Google Calendar
+        # Remove events from Discord that no longer exist in Google Calendar
         google_event_ids = {event['id'] for event in events}
         for synced_event in list(synced_events["events"]):
-            time.sleep(2)
+            time.sleep(2)  # Pause to respect rate limits
             if synced_event["google_event_id"] not in google_event_ids:
                 delete_discord_event(synced_event["discord_event_id"])
                 synced_events["events"].remove(synced_event)
@@ -194,4 +241,5 @@ async def sync_events_loop():
     except Exception as e:
         log_event(f"Error in sync_events_loop: {e}")
 
+# Run the bot using the token from var.py
 bot.run(var.DISCORD_BOT_TOKEN)


### PR DESCRIPTION
This is Release 2. Here I fixed the behavior when modifying an event on Google Calendar that was already present on Discord. The HTTP method was incorrect. Now, updating existing events also works.